### PR TITLE
Fix bundle display name localization issue

### DIFF
--- a/Assets/Locales/LocalizationSettings.asset
+++ b/Assets/Locales/LocalizationSettings.asset
@@ -64,18 +64,18 @@ MonoBehaviour:
       data:
         m_ShortName:
           m_TableReference:
-            m_TableCollectionName: GUID:cefb883c8a2724890a49b69c6e47cd8e
+            m_TableCollectionName: 
           m_TableEntryReference:
-            m_KeyId: 8682527312044032
+            m_KeyId: 0
             m_Key: 
           m_FallbackState: 0
           m_WaitForCompletion: 0
           m_LocalVariables: []
         m_DisplayName:
           m_TableReference:
-            m_TableCollectionName: 
+            m_TableCollectionName: GUID:cefb883c8a2724890a49b69c6e47cd8e
           m_TableEntryReference:
-            m_KeyId: 0
+            m_KeyId: 8682527312044032
             m_Key: 
           m_FallbackState: 0
           m_WaitForCompletion: 0

--- a/Assets/Locales/LocalizedStrings Shared Data.asset
+++ b/Assets/Locales/LocalizedStrings Shared Data.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 8682527312044032
-    m_Key: BundleName
+    m_Key: BundleDisplayName
     m_Metadata:
       m_Items: []
   - m_Id: 8683941459386368

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -171,7 +171,7 @@ PlayerSettings:
     iPhone: com.SeedV.SeedCalc
   buildNumber:
     Standalone: 0
-    iPhone: 0
+    iPhone: 1
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.24f1c2
-m_EditorVersionWithRevision: 2020.3.24f1c2 (f3616f7ef48a)
+m_EditorVersion: 2020.3.26f1c1
+m_EditorVersionWithRevision: 2020.3.26f1c1 (cf0e0a163043)


### PR DESCRIPTION
* Fix #21 by uncheck `English` localization in Xcode (added notes in `Readme.md` of SeedCalcNonOpenSource)
* Fix bundle display name localization issue
* Change build version from `0` to `1`, I think it's better to start from 1.
* Change Unity editor version `to 2020.3.26f1c1`