### PR TITLE
Increase build number to 3 for mac app

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -170,7 +170,7 @@ PlayerSettings:
     Standalone: com.SeedV.SeedCalc
     iPhone: com.SeedV.SeedCalc
   buildNumber:
-    Standalone: 2
+    Standalone: 3
     iPhone: 2
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0


### PR DESCRIPTION
Rebuild Mac app by removing "-o runtime" to fix Mac App release issue.