### PR TITLE
Fix #31, improve shadows for iOS builds

### DIFF
--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -85,7 +85,7 @@ QualitySettings:
     pixelLightCount: 2
     shadows: 2
     shadowResolution: 1
-    shadowProjection: 1
+    shadowProjection: 0
     shadowCascades: 2
     shadowDistance: 40
     shadowNearPlaneOffset: 3
@@ -121,7 +121,7 @@ QualitySettings:
     pixelLightCount: 3
     shadows: 2
     shadowResolution: 2
-    shadowProjection: 1
+    shadowProjection: 0
     shadowCascades: 2
     shadowDistance: 70
     shadowNearPlaneOffset: 3
@@ -157,7 +157,7 @@ QualitySettings:
     pixelLightCount: 4
     shadows: 2
     shadowResolution: 2
-    shadowProjection: 1
+    shadowProjection: 0
     shadowCascades: 4
     shadowDistance: 150
     shadowNearPlaneOffset: 3
@@ -200,5 +200,5 @@ QualitySettings:
     WebGL: 2
     Windows Store Apps: 4
     XboxOne: 4
-    iPhone: 1
+    iPhone: 2
     tvOS: 1


### PR DESCRIPTION
* Set Shadow Projection to "Close Fit" for High/Very High/Ultra quality levels
* Use "High quality" for iOS builds

On iOS, the shadow projection type "Close Fit" significantly improves the shadow rendering quality, solving the ugly edges and the ghost lighting spots issues. See the diff image between "Stable Fit" and "Close Fit":

![diff](https://user-images.githubusercontent.com/5819968/155893917-c31b14aa-3866-4f7f-b15d-a09444cb6952.jpg)

Although, there is still one issue left: Unity on iOS renders relatively much harder shadows than on desktop. "Soft shadow" does not work well on Unity iOS. This is a Unity issue and cannot be fixed easily. Possible solutions may include:

* Use the Unity URP pipeline - this solves the hard shadow issue a little bit on iOS per my test, but the result is still way worse than on desktop.
* Use third-party shadow assets or build our own shaders.

I think the current quality is acceptable. We can re-visit this later if we plan to put more effort to improve this.
