### PR TITLE
Fix #49, add version number to About dialog

### DIFF
--- a/Assets/Locales/LocalizedStrings_en.asset
+++ b/Assets/Locales/LocalizedStrings_en.asset
@@ -39,7 +39,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 8683941459386368
-    m_Localized: About
+    m_Localized: SeedCalc
     m_Metadata:
       m_Items: []
   - m_Id: 8684000355803136

--- a/Assets/Locales/LocalizedStrings_zh-CN.asset
+++ b/Assets/Locales/LocalizedStrings_zh-CN.asset
@@ -39,7 +39,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 8683941459386368
-    m_Localized: "\u5173\u4E8E"
+    m_Localized: "\u770B\u5F97\u89C1\u7684\u8BA1\u7B97\u5668"
     m_Metadata:
       m_Items: []
   - m_Id: 8684000355803136

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27175400cadf9458b7b4881d9ef546b87ca01ecc42c5abdab84ab2cbb4431e8b
-size 976355
+oid sha256:a0d9c37bbc6d9ae33aca4c2e7f99e6488019fe952fc5d340a6d6905249913ee9
+size 980176

--- a/Assets/Src/Scripts/SeedCalc/GameManager.cs
+++ b/Assets/Src/Scripts/SeedCalc/GameManager.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections;
+using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Localization.Settings;
@@ -35,6 +36,7 @@ namespace SeedCalc {
     private Button _soundSwitchButton = null;
     private GameObject _soundOnText = null;
     private GameObject _soundOffText = null;
+    private TMP_Text _aboutVersionText = null;
 
     public void OnClickButton(string input) {
       if (_calculator.AcceptingInput) {
@@ -132,6 +134,11 @@ namespace SeedCalc {
       Debug.Assert(!(_soundOnText is null));
       _soundOffText = _soundSwitchButton.transform.Find("SoundOffText")?.gameObject;
       Debug.Assert(!(_soundOffText is null));
+
+      bk = AboutDialog.transform.Find("Background");
+      _aboutVersionText = bk.Find("AboutVersionText")?.gameObject.GetComponent<TMP_Text>();
+      Debug.Assert(!(_aboutVersionText is null));
+      _aboutVersionText.text = $"v{Application.version}";
     }
 
     IEnumerator Start() {


### PR DESCRIPTION
- There is no good tech solution to retrieve the bundle/build number
  from Unity script.
- Adding version number first then.

See the following screen shots:

![Screen Shot 2022-04-02 at 11 47 19 PM](https://user-images.githubusercontent.com/5819968/161391251-88336c1c-ca9c-440b-8cce-276e09a630bf.png)
![Screen Shot 2022-04-02 at 11 47 34 PM](https://user-images.githubusercontent.com/5819968/161391252-f1293262-d435-43c6-9db8-cf960eca011d.png)

